### PR TITLE
Revert "DEV-20186 Retrait dlls du script prepare_release.ps1"

### DIFF
--- a/prepare_release.ps1
+++ b/prepare_release.ps1
@@ -18,6 +18,10 @@ if (-not (Test-Path -Path "$destinationFolderPath\$VersionNumber" -PathType Cont
 # Copy the executable files
 Copy-Item -Path "$sourceFolderPath\AutonumO\AutonumO.exe" -Destination "$destinationFolderPath\$VersionNumber"
 Copy-Item -Path "$sourceFolderPath\ClasseurO\ClasseurO.exe" -Destination "$destinationFolderPath\$VersionNumber"
+Copy-Item -Path "$sourceFolderPath\ClasseurO\DTKBarReader.dll" -Destination "$destinationFolderPath\$VersionNumber"
+Copy-Item -Path "$sourceFolderPath\ClasseurO\eng.traineddata" -Destination "$destinationFolderPath\$VersionNumber"
+Copy-Item -Path "$sourceFolderPath\ClasseurO\fra.traineddata" -Destination "$destinationFolderPath\$VersionNumber"
+Copy-Item -Path "$sourceFolderPath\ClasseurO\ievision.dll" -Destination "$destinationFolderPath\$VersionNumber"
 Copy-Item -Path "$sourceFolderPath\Installateur\Class_inst.exe" -Destination "$destinationFolderPath\$VersionNumber"
 Copy-Item -Path "$sourceFolderPath\NumO\NumO.exe" -Destination "$destinationFolderPath\$VersionNumber"
 Copy-Item -Path "$sourceFolderPath\TraiteO\TraiteO.exe" -Destination "$destinationFolderPath\$VersionNumber"


### PR DESCRIPTION
This reverts commit 75a6f16b0268148df9c5ba854f5ac96af5c1b654.

[11:11 AM](https://omnimedchat.slack.com/archives/D020H43J04T/p1710861096365719)
Luc Aubin
 Vérifier mise à jour de DTKBarReader.dll
https://github.com/Omnimed/Omnimed-delphi-documentarchiver-releases/releases/latest/download/DTKBarReader.dll
 Version sur le site:
  Fichier non-présent
Vérifier mise à jour de ievision.dll
https://github.com/Omnimed/Omnimed-delphi-documentarchiver-releases/releases/latest/download/ievision.dll
 Version sur le site:
  Fichier non-présent
Vérifier mise à jour de eng.traineddata
https://github.com/Omnimed/Omnimed-delphi-documentarchiver-releases/releases/latest/download/eng.traineddata
 Version sur le site:
  Fichier non-présent
Vérifier mise à jour de fra.traineddata
https://github.com/Omnimed/Omnimed-delphi-documentarchiver-releases/releases/latest/download/fra.traineddata
 Version sur le site:
[11:12 AM](https://omnimedchat.slack.com/archives/D020H43J04T/p1710861137792169)
finalement tu continueras a mettre les autre fichiers sur github car si pour X raison le client en perd un, il peut toujours le récupéerer
[11:30 AM](https://omnimedchat.slack.com/archives/D020H43J04T/p1710862201022069)
Antoine Cloutier
 je les ai enlevé déjà :confused:
[11:30 AM](https://omnimedchat.slack.com/archives/D020H43J04T/p1710862231406499)
Luc Aubin
 remet les